### PR TITLE
feat: implement lexer

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,43 @@
+name: "Go"
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: Lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1.6
+          args: --timeout=10m --issues-exit-code=0
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Test
+        run: |
+          go test ./... -v

--- a/srt/internal/lexer/lexer.go
+++ b/srt/internal/lexer/lexer.go
@@ -1,0 +1,131 @@
+package lexer
+
+import (
+	"unicode"
+
+	"github.com/florentsorel/subtitle/srt/internal/token"
+)
+
+type Lexer struct {
+	input        string
+	position     int
+	nextPosition int
+	ch           rune
+	line         int
+	column       int
+}
+
+// New creates a new Lexer instance with the provided input string.
+func New(input string) *Lexer {
+	l := &Lexer{input: input, line: 1, column: 0}
+	l.readChar()
+	return l
+}
+
+// readChar reads the next character from the input and updates the position and line/column counters.
+func (l *Lexer) readChar() {
+	if l.nextPosition >= len(l.input) {
+		l.ch = 0
+	} else {
+		l.ch = rune(l.input[l.nextPosition])
+	}
+
+	l.position = l.nextPosition
+	l.nextPosition++
+
+	if l.ch == '\n' {
+		l.line++
+		l.column = 0
+	} else {
+		l.column++
+	}
+}
+
+// NextToken returns the next token from the input string.
+func (l *Lexer) NextToken() token.Token {
+	l.skipWhitespaceExpectNewLine()
+
+	if l.ch == 0 {
+		return token.Token{Type: token.EOF, Literal: "", Line: l.line, Column: 0}
+	}
+
+	switch {
+	case unicode.IsDigit(l.ch):
+		return l.lexNumberOrTimestamp()
+	case l.ch == '\n':
+		l.readChar()
+		return token.Token{Type: token.EOL, Literal: "\n", Line: l.line, Column: 0}
+	case l.ch == '-' && l.nextChar() == '-' && l.peekAhead(2) == '>':
+		startPos := l.position
+		line := l.line
+		col := l.column
+		l.readChar()
+		l.readChar()
+		l.readChar()
+		literal := l.input[startPos:l.position]
+		return token.Token{Type: token.ARROW, Literal: literal, Line: line, Column: col}
+	default:
+		return l.lexText()
+	}
+}
+
+// lexNumberOrTimestamp lexes a number or timestamp from the input string.
+func (l *Lexer) lexNumberOrTimestamp() token.Token {
+	startPos := l.position
+	line := l.line
+	col := l.column
+	hasColon := false
+	hasComma := false
+
+	for unicode.IsDigit(l.ch) || l.ch == ':' || l.ch == ',' {
+		if l.ch == ':' {
+			hasColon = true
+		}
+		if l.ch == ',' {
+			hasComma = true
+		}
+		l.readChar()
+	}
+
+	literal := l.input[startPos:l.position]
+	if hasColon && hasComma {
+		return token.Token{Type: token.TIMESTAMP, Literal: literal, Line: line, Column: col}
+	}
+	return token.Token{Type: token.INDEX, Literal: literal, Line: line, Column: col}
+}
+
+// lexText lexes a text string from the input string.
+func (l *Lexer) lexText() token.Token {
+	startPos := l.position
+	line := l.line
+	col := l.column
+
+	for l.ch != 0 && l.ch != '\n' {
+		l.readChar()
+	}
+	literal := l.input[startPos:l.position]
+	return token.Token{Type: token.TEXT, Literal: literal, Line: line, Column: col}
+}
+
+// nextChar returns the next character in the input without advancing the position.
+func (l *Lexer) nextChar() rune {
+	if l.nextPosition >= len(l.input) {
+		return 0
+	}
+	return rune(l.input[l.nextPosition])
+}
+
+// peekAhead returns the character at the specified offset from the current position without advancing the position.
+func (l *Lexer) peekAhead(n int) rune {
+	if l.nextPosition+n-1 >= len(l.input) {
+		return 0
+	}
+	return rune(l.input[l.nextPosition+n-1])
+}
+
+// skipWhitespaceExpectNewLine skips whitespace characters until a newline character is encountered.
+func (l *Lexer) skipWhitespaceExpectNewLine() {
+	for unicode.IsSpace(l.ch) && l.ch != '\n' {
+		l.readChar()
+	}
+}

--- a/srt/internal/lexer/lexer_test.go
+++ b/srt/internal/lexer/lexer_test.go
@@ -1,0 +1,56 @@
+package lexer
+
+import (
+	"testing"
+
+	"github.com/florentsorel/subtitle/srt/internal/token"
+)
+
+func TestNewLexer(t *testing.T) {
+	input := `1
+00:00:01,123 --> 00:00:01,456
+Text block éè
+Second line
+`
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+		expectedLine    int
+		expectedColumn  int
+	}{
+		{token.INDEX, "1", 1, 1},
+		{token.EOL, "\n", 2, 0},
+		{token.TIMESTAMP, "00:00:01,123", 2, 1},
+		{token.ARROW, "-->", 2, 14},
+		{token.TIMESTAMP, "00:00:01,456", 2, 18},
+		{token.EOL, "\n", 3, 0},
+		{token.TEXT, "Text block éè", 3, 1},
+		{token.EOL, "\n", 4, 0},
+		{token.TEXT, "Second line", 4, 1},
+		{token.EOL, "\n", 5, 0},
+		{token.EOF, "", 5, 0},
+	}
+
+	lexer := New(input)
+
+	for i, tt := range tests {
+		tok := lexer.NextToken()
+
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - TokenType. expected=%q, got=%q.", i, tt.expectedType, tok.Type)
+		}
+
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal. expected=%q, got=%q.", i, tt.expectedLiteral, tok.Literal)
+		}
+
+		if tok.Line != tt.expectedLine {
+			t.Fatalf("tests[%d] - Line. expected=%d, got=%d.", i, tt.expectedLine, tok.Line)
+		}
+
+		if tok.Column != tt.expectedColumn {
+			t.Fatalf("tests[%d] - Column. expected=%d, got=%d.", i, tt.expectedColumn, tok.Column)
+		}
+	}
+}

--- a/srt/internal/token/token.go
+++ b/srt/internal/token/token.go
@@ -1,0 +1,19 @@
+package token
+
+type TokenType string
+
+type Token struct {
+	Type    TokenType
+	Literal string
+	Line    int
+	Column  int
+}
+
+const (
+	INDEX     = "INDEX"
+	TIMESTAMP = "TIMESTAMP"
+	ARROW     = "ARROW"
+	TEXT      = "TEXT"
+	EOL       = "EOL"
+	EOF       = "EOF"
+)


### PR DESCRIPTION
This pull request introduces a lexer for parsing SubRip Subtitle (SRT) files, along with a token definition module and corresponding test cases. The lexer is designed to tokenize SRT file content into meaningful components like timestamps, text, and special symbols. Below are the key changes:

### Lexer Implementation

* Added a new `Lexer` struct in `srt/internal/lexer/lexer.go` to tokenize input strings. It includes methods for reading characters, skipping whitespace, and identifying tokens such as timestamps, text, and arrows (`-->`).
* Implemented tokenization logic for handling different token types, including `INDEX`, `TIMESTAMP`, `ARROW`, `TEXT`, `EOL`, and `EOF`.

### Token Definition

* Created a `Token` struct and associated constants in `srt/internal/token/token.go` to represent the different token types and their attributes (type, literal value, line, and column).

### Testing

* Added unit tests in `srt/internal/lexer/lexer_test.go` to validate the lexer's behavior. The tests ensure that the lexer correctly identifies and returns tokens for various SRT file components, including timestamps, text blocks, and line breaks.