### PR TITLE
feat: implement parser

### DIFF
--- a/srt/internal/lexer/lexer.go
+++ b/srt/internal/lexer/lexer.go
@@ -52,9 +52,15 @@ func (l *Lexer) NextToken() token.Token {
 	switch {
 	case unicode.IsDigit(l.ch):
 		return l.lexNumberOrTimestamp()
-	case l.ch == '\n':
+	case l.ch == '\n' && l.nextChar() == '\n':
+		line := l.line
 		l.readChar()
-		return token.Token{Type: token.EOL, Literal: "\n", Line: l.line, Column: 0}
+		l.readChar()
+		return token.Token{Type: token.EOC, Literal: "\n\n", Line: line, Column: 0}
+	case l.ch == '\n':
+		line := l.line
+		l.readChar()
+		return token.Token{Type: token.EOL, Literal: "\n", Line: line, Column: 0}
 	case l.ch == '-' && l.nextChar() == '-' && l.peekAhead(2) == '>':
 		startPos := l.position
 		line := l.line

--- a/srt/internal/lexer/lexer_test.go
+++ b/srt/internal/lexer/lexer_test.go
@@ -11,6 +11,8 @@ func TestNewLexer(t *testing.T) {
 00:00:01,123 --> 00:00:01,456
 Text block éè
 Second line
+
+2
 `
 
 	tests := []struct {
@@ -28,8 +30,10 @@ Second line
 		{token.TEXT, "Text block éè", 3, 1},
 		{token.EOL, "\n", 4, 0},
 		{token.TEXT, "Second line", 4, 1},
-		{token.EOL, "\n", 5, 0},
-		{token.EOF, "", 5, 0},
+		{token.EOC, "\n\n", 5, 0},
+		{token.INDEX, "2", 6, 1},
+		{token.EOL, "\n", 7, 0},
+		{token.EOF, "", 7, 0},
 	}
 
 	lexer := New(input)

--- a/srt/internal/parser/parser.go
+++ b/srt/internal/parser/parser.go
@@ -1,0 +1,129 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/florentsorel/subtitle"
+	"github.com/florentsorel/subtitle/srt/internal/lexer"
+	"github.com/florentsorel/subtitle/srt/internal/token"
+)
+
+type Parser struct {
+	lexer        *lexer.Lexer
+	currentToken token.Token
+	nextToken    token.Token
+}
+
+func New(l *lexer.Lexer) *Parser {
+	p := &Parser{lexer: l}
+	p.readToken()
+	p.readToken()
+	return p
+}
+
+func (p *Parser) readToken() {
+	p.currentToken = p.nextToken
+	p.nextToken = p.lexer.NextToken()
+}
+
+func (p *Parser) Parse() ([]subtitle.Subtitle, error) {
+	var subs []subtitle.Subtitle
+
+	for p.currentToken.Type != token.EOF {
+		cue, err := p.parseCue()
+		if err != nil {
+			return nil, err
+		}
+		subs = append(subs, cue)
+	}
+
+	return subs, nil
+}
+
+func (p *Parser) parseCue() (subtitle.Subtitle, error) {
+	var s subtitle.Subtitle
+
+	// Index
+	if p.currentToken.Type != token.INDEX {
+		return s, fmt.Errorf("expected INDEX, got %s at line %d, column %d", p.currentToken.Type, p.currentToken.Line, p.currentToken.Column)
+	}
+	index, err := strconv.Atoi(p.currentToken.Literal)
+	if err != nil {
+		return s, err
+	}
+	s.Index = index
+	p.readToken()
+
+	// End of line
+	if p.currentToken.Type != token.EOL {
+		return s, fmt.Errorf("expected EOL, got %s at line %d, column %d", p.currentToken.Type, p.currentToken.Line, p.currentToken.Column)
+	}
+	p.readToken()
+
+	// Start time
+	if p.currentToken.Type != token.TIMESTAMP {
+		return s, fmt.Errorf("expected TIMESTAMP, got %s at line %d, column %d", p.currentToken.Type, p.currentToken.Line, p.currentToken.Column)
+	}
+	startTime, err := parseTimestamp(p.currentToken.Literal)
+	if err != nil {
+		return s, err
+	}
+	s.Start = startTime
+
+	p.readToken()
+
+	// Arrow
+	if p.currentToken.Type != token.ARROW {
+		return s, fmt.Errorf("expected ARROW, got %s at line %d, column %d", p.currentToken.Type, p.currentToken.Line, p.currentToken.Column)
+	}
+
+	p.readToken()
+
+	// End time
+	if p.currentToken.Type != token.TIMESTAMP {
+		return s, fmt.Errorf("expected TIMESTAMP, got %s at line %d, column %d", p.currentToken.Type, p.currentToken.Line, p.currentToken.Column)
+	}
+	endTime, err := parseTimestamp(p.currentToken.Literal)
+	if err != nil {
+		return s, err
+	}
+	s.End = endTime
+
+	p.readToken()
+
+	var textLines []string
+	for p.currentToken.Type != token.EOF && p.currentToken.Type != token.INDEX {
+		switch p.currentToken.Type {
+		case token.TEXT:
+			textLines = append(textLines, p.currentToken.Literal)
+		case token.EOL:
+			if p.nextToken.Type == token.TEXT {
+				textLines = append(textLines, "")
+			}
+		}
+		p.readToken()
+	}
+
+	if p.currentToken.Type == token.INDEX {
+		p.currentToken = p.nextToken
+		p.nextToken = p.lexer.NextToken()
+	}
+
+	s.Text = strings.Join(textLines, "\n")
+
+	return s, nil
+}
+
+func parseTimestamp(s string) (time.Time, error) {
+	normalized := strings.Replace(s, ",", ".", 1)
+	const layout = "15:04:05.000"
+
+	t, err := time.Parse(layout, normalized)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t, nil
+}

--- a/srt/internal/parser/parser_test.go
+++ b/srt/internal/parser/parser_test.go
@@ -1,0 +1,84 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/florentsorel/subtitle/srt/internal/lexer"
+)
+
+func TestNewParser(t *testing.T) {
+	tests := []struct {
+		input         string
+		expectedError string
+	}{
+		{
+			input:         `-->`,
+			expectedError: "expected INDEX, got ARROW at line 1, column 1",
+		},
+		{
+			input:         `00:00:01,123`,
+			expectedError: "expected INDEX, got TIMESTAMP at line 1, column 1",
+		},
+		{
+			input:         `1 00:00:01,123`,
+			expectedError: "expected EOL, got TIMESTAMP at line 1, column 3",
+		},
+		{
+			input: `1
+-->`,
+			expectedError: "expected TIMESTAMP, got ARROW at line 2, column 1",
+		},
+		{
+			input: `1
+00:00:01,123 00:00:01,456`,
+			expectedError: "expected ARROW, got TIMESTAMP at line 2, column 14",
+		},
+		{
+			input: `1
+00:00:01,123 --> hello`,
+			expectedError: "expected TIMESTAMP, got TEXT at line 2, column 18",
+		},
+		{
+			input: `1
+00:00:01,123 --> 00:00:01,456
+First line
+Second line
+
+-->`,
+			expectedError: "expected INDEX, got ARROW at line 6, column 1",
+		},
+		{
+			input: `1
+00:00:01,123 --> 00:00:01,456
+First line
+Second line
+
+2
+00:00:01,123 --> 00:00:01,456
+First line
+
+text`,
+			expectedError: "expected INDEX, got TEXT at line 10, column 1",
+		},
+		{
+			input: `1
+00:00:01,123 --> 00:00:01,456
+First line
+Second line
+2
+00:00:01,123 --> 00:00:01,456
+First line`,
+			expectedError: "expected EOL (EOB), got TIMESTAMP at line 5, column 1",
+		},
+	}
+
+	for i, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		_, err := p.Parse()
+
+		if err == nil || err.Error() != tt.expectedError {
+			t.Fatalf("test[%d] - expected=%q, got=%q.", i, tt.expectedError, err)
+		}
+	}
+}

--- a/srt/internal/parser/parser_test.go
+++ b/srt/internal/parser/parser_test.go
@@ -16,6 +16,10 @@ func TestNewParser(t *testing.T) {
 			expectedError: "expected INDEX, got ARROW at line 1, column 1",
 		},
 		{
+			input:         `First line`,
+			expectedError: "expected INDEX, got TEXT at line 1, column 1",
+		},
+		{
 			input:         `00:00:01,123`,
 			expectedError: "expected INDEX, got TIMESTAMP at line 1, column 1",
 		},
@@ -30,22 +34,29 @@ func TestNewParser(t *testing.T) {
 		},
 		{
 			input: `1
-00:00:01,123 00:00:01,456`,
-			expectedError: "expected ARROW, got TIMESTAMP at line 2, column 14",
-		},
-		{
-			input: `1
-00:00:01,123 --> hello`,
-			expectedError: "expected TIMESTAMP, got TEXT at line 2, column 18",
+00:00:01,123 --> 00:00:01,456
+First line
+Second line
+2
+00:00:01,123 --> 00:00:01,456
+First line`,
+			expectedError: "expected EOC, got INDEX at line 5, column 1",
 		},
 		{
 			input: `1
 00:00:01,123 --> 00:00:01,456
 First line
 Second line
-
 -->`,
-			expectedError: "expected INDEX, got ARROW at line 6, column 1",
+			expectedError: "expected EOC, got ARROW at line 5, column 1",
+		},
+		{
+			input: `1
+00:00:01,123 --> 00:00:01,456
+First line
+Second line
+00:00:01,123`,
+			expectedError: "expected EOC, got TIMESTAMP at line 5, column 1",
 		},
 		{
 			input: `1
@@ -65,10 +76,16 @@ text`,
 00:00:01,123 --> 00:00:01,456
 First line
 Second line
+
 2
 00:00:01,123 --> 00:00:01,456
-First line`,
-			expectedError: "expected EOL (EOB), got TIMESTAMP at line 5, column 1",
+First line
+
+3
+00:00:01,123 --> 00:00:01,456
+text
+toto`,
+			expectedError: "",
 		},
 	}
 
@@ -77,7 +94,11 @@ First line`,
 		p := New(l)
 		_, err := p.Parse()
 
-		if err == nil || err.Error() != tt.expectedError {
+		if tt.expectedError == "" {
+			if err != nil {
+				t.Fatalf("test[%d] - expected no error, got=%q.", i, err)
+			}
+		} else if err == nil || err.Error() != tt.expectedError {
 			t.Fatalf("test[%d] - expected=%q, got=%q.", i, tt.expectedError, err)
 		}
 	}

--- a/srt/internal/token/token.go
+++ b/srt/internal/token/token.go
@@ -15,5 +15,6 @@ const (
 	ARROW     = "ARROW"
 	TEXT      = "TEXT"
 	EOL       = "EOL"
+	EOC       = "EOC"
 	EOF       = "EOF"
 )

--- a/srt/srt.go
+++ b/srt/srt.go
@@ -1,0 +1,14 @@
+package srt
+
+import (
+	"github.com/florentsorel/subtitle"
+	"github.com/florentsorel/subtitle/srt/internal/lexer"
+	"github.com/florentsorel/subtitle/srt/internal/parser"
+)
+
+func Parse(input string) ([]subtitle.Subtitle, error) {
+	l := lexer.New(input)
+	p := parser.New(l)
+
+	return p.Parse()
+}

--- a/srt/srt.go
+++ b/srt/srt.go
@@ -6,9 +6,9 @@ import (
 	"github.com/florentsorel/subtitle/srt/internal/parser"
 )
 
-func Parse(input string) ([]subtitle.Subtitle, error) {
+// Parse parses the input string and returns a slice of subtitle.Cue.
+func Parse(input string) ([]subtitle.Cue, error) {
 	l := lexer.New(input)
 	p := parser.New(l)
-
 	return p.Parse()
 }

--- a/srt/srt_test.go
+++ b/srt/srt_test.go
@@ -1,0 +1,97 @@
+package srt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/florentsorel/subtitle"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		input             string
+		expectedSubtitles []subtitle.Cue
+	}{
+		{
+			input: `1
+00:00:01,123 --> 00:00:02,456
+First line
+Second line
+
+2
+00:00:03,123 --> 00:00:04,456
+Single line
+
+3
+00:00:05,123 --> 00:00:06,456
+Last cue
+Last line`,
+			expectedSubtitles: []subtitle.Cue{
+				{
+					Index: 1,
+					Start: parseTime("00:00:01,123"),
+					End:   parseTime("00:00:02,456"),
+					Text:  "First line\nSecond line",
+				},
+				{
+					Index: 2,
+					Start: parseTime("00:00:03,123"),
+					End:   parseTime("00:00:04,456"),
+					Text:  "Single line",
+				},
+				{
+					Index: 3,
+					Start: parseTime("00:00:05,123"),
+					End:   parseTime("00:00:06,456"),
+					Text:  "Last cue\nLast line",
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		subtitles, err := Parse(tt.input)
+
+		if err != nil {
+			t.Fatalf("test[%d] - unexpected error: %v", i, err)
+		}
+
+		if len(subtitles) != len(tt.expectedSubtitles) {
+			t.Fatalf("test[%d] - wrong number of subtitles. expected=%d, got=%d",
+				i, len(tt.expectedSubtitles), len(subtitles))
+		}
+
+		for j, sub := range subtitles {
+			expected := tt.expectedSubtitles[j]
+
+			if sub.Index != expected.Index {
+				t.Fatalf("test[%d][%d] - wrong index. expected=%d, got=%d",
+					i, j, expected.Index, sub.Index)
+			}
+
+			if !sub.Start.Equal(expected.Start) {
+				t.Fatalf("test[%d][%d] - wrong start time. expected=%v, got=%v",
+					i, j, expected.Start, sub.Start)
+			}
+
+			if !sub.End.Equal(expected.End) {
+				t.Fatalf("test[%d][%d] - wrong end time. expected=%v, got=%v",
+					i, j, expected.End, sub.End)
+			}
+
+			if sub.Text != expected.Text {
+				t.Fatalf("test[%d][%d] - wrong text. expected=%q, got=%q",
+					i, j, expected.Text, sub.Text)
+			}
+		}
+	}
+}
+
+func parseTime(s string) time.Time {
+	normalized := s
+	if len(s) > 0 {
+		normalized = s[:8] + "." + s[9:]
+	}
+	t, _ := time.Parse("15:04:05.000", normalized)
+	return t
+}

--- a/subtitle.go
+++ b/subtitle.go
@@ -1,0 +1,10 @@
+package subtitle
+
+import "time"
+
+type Subtitle struct {
+	Index int
+	Start time.Time
+	End   time.Time
+	Text  string
+}

--- a/subtitle.go
+++ b/subtitle.go
@@ -2,7 +2,7 @@ package subtitle
 
 import "time"
 
-type Subtitle struct {
+type Cue struct {
 	Index int
 	Start time.Time
 	End   time.Time


### PR DESCRIPTION
This pull request introduces a new subtitle parsing system for the SRT format, including updates to the lexer, the addition of a parser, and comprehensive tests. Key changes include the implementation of a parser to handle SRT cues, updates to the lexer to support end-of-cue tokens, and the creation of a high-level `Parse` function for SRT files.

### Lexer Enhancements:
* Added support for recognizing end-of-cue (`EOC`) tokens in the lexer to differentiate between cue blocks. (`srt/internal/lexer/lexer.go`
* Updated lexer tests to validate the handling of `EOC` tokens and additional cue blocks. (`srt/internal/lexer/lexer_test.go`

### Parser Implementation:
* Introduced a new `parser` package with a `Parser` struct and methods for parsing SRT cues, including handling indices, timestamps, and cue text. 
* Added unit tests for the parser to ensure robust error handling and correct parsing of SRT input. 

### Token Updates:
* Added a new `EOC` token type to the `token` package to represent the end of a cue block. 

### High-Level SRT Parsing:
* Created a high-level `Parse` function in the `srt` package that integrates the lexer and parser to parse SRT input into a slice of `subtitle.Cue` structs.
* Added integration tests for the `Parse` function to validate end-to-end functionality of the SRT parsing system. 

### Subtitle Data Model:
* Introduced a `Cue` struct in the `subtitle` package to represent individual subtitle cues, including index, start time, end time, and text.